### PR TITLE
Show load and file_extensions in accessors

### DIFF
--- a/docs/src/utilities.jl
+++ b/docs/src/utilities.jl
@@ -14,7 +14,7 @@ A.accessors()
 
 @test length(A.accessors()) == 37 #src
 
-@test length(A.required_accessors()) == 11 #src
+@test length(A.required_accessors()) == 13 #src
 
 # You do not need to overload all of them (e.g., if you model does not have any
 # genes you can completely omit all gene-related functions). The main required

--- a/docs/src/utilities.jl
+++ b/docs/src/utilities.jl
@@ -12,7 +12,7 @@ import AbstractFBCModels as A
 
 A.accessors()
 
-@test length(A.accessors()) == 35 #src
+@test length(A.accessors()) == 37 #src
 
 @test length(A.required_accessors()) == 11 #src
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,12 +33,6 @@ $(TYPEDSIGNATURES)
 
 Provide a `methodswith`-style listing of accessors that the model implementors
 may implement.
-
-For typesystem reasons, the list **will not contain** methods for
-[`load`](@ref) and [`filename_extensions`](@ref) that dispatch on type objects.
-You should implement these as well.
-
-See also [`required_accessors`](@ref) for the minimal list that must be implemented.
 """
 function accessors()
     ms = Method[]
@@ -48,6 +42,18 @@ function accessors()
             methodswith(AbstractFBCModels.AbstractFBCModel, f, ms)
         end
     end
+
+    # special case these as they take the type not the instance
+    for f in (AbstractFBCModels.load, AbstractFBCModels.filename_extensions)
+        for m in methods(f)
+            m.sig isa UnionAll || continue
+            type_param = Base.unwrap_unionall(m.sig).parameters[2].parameters[1].ub
+            if type_param == AbstractFBCModels.AbstractFBCModel
+                push!(ms, m)
+            end
+        end
+    end
+
     return ms
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,6 +28,7 @@ end
 unimplemented(t::Type, x::Symbol) =
     error("AbstractFBCModels interface method $x is not implemented for type $t")
 
+
 """
 $(TYPEDSIGNATURES)
 
@@ -43,10 +44,17 @@ function accessors()
         end
     end
 
+    append!(ms, _type_accessors())
+    return ms
+end
+
+function _type_accessors()
     # special case these as they take the type not the instance
+    ms = Method[]
     for f in (AbstractFBCModels.load, AbstractFBCModels.filename_extensions)
         for m in methods(f)
             m.sig isa UnionAll || continue
+            # Deep magic: basically this matches on `f(::Type{A},...) where A<:AbstractFBCModel`
             type_param = Base.unwrap_unionall(m.sig).parameters[2].parameters[1].ub
             if type_param == AbstractFBCModels.AbstractFBCModel
                 push!(ms, m)
@@ -56,6 +64,7 @@ function accessors()
 
     return ms
 end
+
 
 """
 $(TYPEDSIGNATURES)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,7 +49,7 @@ function accessors()
 end
 
 function _type_accessors()
-    # special case these as they take the type not the instance
+    # special case: some "accessors" take the Type argument instead of actual instance
     ms = Method[]
     for f in (AbstractFBCModels.load, AbstractFBCModels.filename_extensions)
         for m in methods(f)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,6 +85,7 @@ function required_accessors()
     for f in REQUIRED_ACCESSORS
         methodswith(AbstractFBCModels.AbstractFBCModel, f, ms)
     end
+    append!(ms, _type_accessors())
     return ms
 end
 


### PR DESCRIPTION
Like #26 this seemed an interesting intellectual exercise.
This functionality looks scary and technically it is internals.
But I have been using it in ExprTools.jl in like every version of julia back til 1.0
Having to use an internal method for this is another manifestation of https://github.com/JuliaLang/julia/issues/20555

I put this in a helper function so that after #26 we could add it to that list also