### PR TITLE
Define line numbers for functions defined using required macro

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -16,11 +16,15 @@ macro required(sig)
     model_arg = model_arg_ex.args[1]
     model_arg isa Symbol || error("malformed signature definition")
 
+    # magic to use the call-site line numbers so methods includes them
+    def = Expr(:(=), call_ex, Expr(:block, __source__, 
+        :($unimplemented(typeof($model_arg), $(Meta.quot(name))))
+    ))
     return esc(
         quote
-            Base.@__doc__ $call_ex = $unimplemented(typeof($model_arg), $(Meta.quot(name)))
+            $def
             push!(REQUIRED_ACCESSORS, $name)
-            $name
+            Base.@__doc__ $name
         end,
     )
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -17,16 +17,16 @@ macro required(sig)
     model_arg isa Symbol || error("malformed signature definition")
 
     # magic to use the call-site line numbers so methods includes them
-    def = Expr(:(=), call_ex, Expr(:block, __source__, 
-        :($unimplemented(typeof($model_arg), $(Meta.quot(name))))
-    ))
-    return esc(
-        quote
-            $def
-            push!(REQUIRED_ACCESSORS, $name)
-            Base.@__doc__ $name
-        end,
+    def = Expr(
+        :(=),
+        call_ex,
+        Expr(:block, __source__, :($unimplemented(typeof($model_arg), $(Meta.quot(name))))),
     )
+    return esc(quote
+        $def
+        push!(REQUIRED_ACCESSORS, $name)
+        Base.@__doc__ $name
+    end)
 end
 
 unimplemented(t::Type, x::Symbol) =


### PR DESCRIPTION
That was a bit tricky, but I got there in the end.

```
julia> using AbstractFBCModels
[ Info: Precompiling AbstractFBCModels [5a4f3dfa-1789-40f8-8221-69268c29937c]

julia> AbstractFBCModels.required_accessors()
[1] reactions(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:13
[2] n_reactions(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:22
[3] metabolites(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:32
[4] n_metabolites(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:42
[5] genes(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:52
[6] n_genes(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:63
[7] stoichiometry(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:97
[8] bounds(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:115
[9] objective(a::AbstractFBCModels.AbstractFBCModel) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:140
[10] reaction_stoichiometry(a::AbstractFBCModels.AbstractFBCModel, reaction_id::String) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/accessors.jl:191
[11] save(a::AbstractFBCModels.AbstractFBCModel, path::String) @ AbstractFBCModels ~/repos/AbstractFBCModels.jl/src/io.jl:16

help?> AbstractFBCModels.save
  Save a model to the given path.
```